### PR TITLE
Bug 1986520 - Seperate single homeview and shopify graphs into platform specific graphs

### DIFF
--- a/android.html
+++ b/android.html
@@ -91,13 +91,33 @@
           unit: "ms"
         },
         {
-          name: "shopify-applink-startup",
-          metric: ["shopify-applink-startup"],
+          name: "shopify-applink-startup (A55)",
+          metric: ["shopify-applink-startup-a55"],
           unit: "ms"
         },
         {
-          name: "homeview-startup",
-          metric: ["homeview_startup"],
+          name: "shopify-applink-startup (P6)",
+          metric: ["shopify-applink-startup-p6"],
+          unit: "ms"
+        },
+        {
+          name: "shopify-applink-startup (S24)",
+          metric: ["shopify-applink-startup-s24"],
+          unit: "ms"
+        },
+        {
+          name: "homeview-startup (A55)",
+          metric: ["homeview-startup-a55"],
+          unit: "ms"
+        },
+        {
+          name: "homeview-startup (P6)",
+          metric: ["homeview-startup-p6"],
+          unit: "ms"
+        },
+        {
+          name: "homeview-startup (S24)",
+          metric: ["homeview-startup-s24"],
           unit: "ms"
         },
         {

--- a/assets/android-metrics.js
+++ b/assets/android-metrics.js
@@ -269,8 +269,18 @@ function fixupStartupTests(data) {
       row.test = 'newssite-applink-startup-p6';
     } else if (row.test === 'applink_startup' && row.suite === 'newssite-applink-startup' && row.platform === 'android-hw-s24-14-0-aarch64-shippable') {
       row.test = 'newssite-applink-startup-s24';
-    } else if (row.test === 'applink_startup' && row.suite === 'shopify-applink-startup') {
-      row.test = 'shopify-applink-startup';
+    } else if (row.test === 'applink_startup' && row.suite === 'shopify-applink-startup' && row.platform === 'android-hw-a55-14-0-aarch64-shippable') {
+      row.test = 'shopify-applink-startup-a55';
+    } else if (row.test === 'applink_startup' && row.suite === 'shopify-applink-startup' && row.platform === 'android-hw-p6-13-0-aarch64-shippable') {
+      row.test = 'shopify-applink-startup-p6';
+    } else if (row.test === 'applink_startup' && row.suite === 'shopify-applink-startup' && row.platform === 'android-hw-s24-14-0-aarch64-shippable') {
+      row.test = 'shopify-applink-startup-s24';
+    } else if ( row.test === 'homeview_startup' && row.suite === 'homeview-startup' && row.platform === 'android-hw-a55-14-0-aarch64-shippable') {
+      row.test = 'homeview-startup-a55';
+    } else if ( row.test === 'homeview_startup' && row.suite === 'homeview-startup' && row.platform === 'android-hw-p6-13-0-aarch64-shippable') {
+      row.test = 'homeview-startup-p6';
+    } else if ( row.test === 'homeview_startup' && row.suite === 'homeview-startup' && row.platform === 'android-hw-s24-14-0-aarch64-shippable') {
+      row.test = 'homeview-startup-s24';
     }
   });
 }


### PR DESCRIPTION
Previously we were only running the homview and shopify applink startup tests on the a55, there was no need for device filtering. 

When started running those tests on the P6 and S24 all the data for homeview and shopify applink blended into one graph causing confusion,

This fix creates 3 graphs per test for each hardware platform and removes the confusing single trimodal graph.